### PR TITLE
remove package_cloud from deploy

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -9,7 +9,6 @@ deploy:
     # Use auto-dist-tag to still allow publishing beta, alpha, and rc versions
     - npx auto-dist-tag --write
   override:
-    - bundle exec package_cloud push shopify/gems pkg/*.gem
     - npm publish
 review:
   checklist:


### PR DESCRIPTION
rubygems deploy isn’t happening. let’s see if removing this helps.