### PR TITLE
Remove director

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,5 +1,4 @@
 # https://services.shopify.io/services/polaris-tokens/production
-director: kpeatt
 owners:
 - Shopify/polaris
 production:


### PR DESCRIPTION
**Owners**: @Shopify/polaris
**Service**: [polaris-tokens/production](https://services.shopify.io/services/polaris-tokens/production)

Director ownership has been deprecated in favour of Product/Service Line ownership.

For more information on service ownership, you can read the docs in [Services DB](https://services.shopify.io/doc/ownership).
