### PR TITLE
Enable CLA bot

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,2 @@
+enabled:
+  - cla


### PR DESCRIPTION
https://cla.shopify.com is officially live. We are going to add it to a few open source projects as a canary test.