### PR TITLE
Revert "Enable CLA bot"

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,2 +1,0 @@
-enabled:
-  - cla


### PR DESCRIPTION
Reverts Shopify/polaris-tokens#34

We discovered a bug with the GitHub checks API and working on a fix. Let’s disable it in the meantime.