### PR TITLE
Use import instead of require

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ const tokens = require('@shopify/polaris-tokens/dist/index.json');
 console.log(tokens['color-blue-lighter']); // rgb(235, 245, 250)
 ```
 
+Note that, if your project supports ECMAScript Modules, you can also use the `import` syntax.
+
+```js
+import * as tokens from '@shopify/polaris-tokens';
+// or
+import { colorBlueLighter } from '@shopify/polaris-tokens';
+```
+
 ### Sass
 
 Sass variables and map keys are formatted in [kebab-case](http://wiki.c2.com/?KebabCase).

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Find all available tokens in the [design tokens documentation](https://shopify.g
 In JavaScript, design token names are formatted in [lower camelCase](http://wiki.c2.com/?CamelCase).
 
 ```js
-import tokens from '@shopify/polaris-tokens';
+const tokens = require('@shopify/polaris-tokens');
 console.log(tokens.colorBlueLighter); // rgb(235, 245, 250)
 ```
 
 In JSON, design token names are formatted in [kebab-case](http://wiki.c2.com/?KebabCase).
 
 ```js
-import tokens from '@shopify/polaris-tokens/dist/index.json';
+const tokens = require('@shopify/polaris-tokens/dist/index.json');
 console.log(tokens['color-blue-lighter']); // rgb(235, 245, 250)
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Find all available tokens in the [design tokens documentation](https://shopify.g
 In JavaScript, design token names are formatted in [lower camelCase](http://wiki.c2.com/?CamelCase).
 
 ```js
-const tokens = require('@shopify/polaris-tokens');
+import tokens from '@shopify/polaris-tokens';
 console.log(tokens.colorBlueLighter); // rgb(235, 245, 250)
 ```
 
 In JSON, design token names are formatted in [kebab-case](http://wiki.c2.com/?KebabCase).
 
 ```js
-const tokens = require('@shopify/polaris-tokens/dist/index.json');
+import tokens from '@shopify/polaris-tokens/dist/index.json';
 console.log(tokens['color-blue-lighter']); // rgb(235, 245, 250)
 ```
 


### PR DESCRIPTION
This switches the example Javascript usage from using `require` to using `import`. 

From what I've seen, the use of `require` has lead to projects which support `import` mixing in `require` under the false assumption that it must be used instead. Clearly this is not the case, as `import` is used for `polaris-tokens` in a bunch of places.

If we want to make it clear both work, we could mention both syntaxes. 🤔 