### PR TITLE
Add spacing-map format

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,6 +62,7 @@ spacing.json
 spacing.map.scss
 spacing.raw.json
 spacing.scss
+spacing.spacing-map.scss
 typography.common.js
 typography.custom-properties.css
 typography.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- ## [Unreleased] -->
 
+## [2.3.0] - 2019-02-19
+
+- Added spacing-map format, usable as `spacing.spacing-map.scss` ([#52](https://github.com/Shopify/polaris-tokens/pull/52))
+
 ## [2.2.0] - 2019-02-19
 
 - Updated devDependencies ([#45](https://github.com/Shopify/polaris-tokens/pull/45))
@@ -67,7 +71,8 @@ Color design tokens are now used in:
 - `Shopify/polaris-styleguide`
 - `Shopify/polaris-react` (`@shopify/polaris` v2 on npm)
 
-[unreleased]: https://github.com/Shopify/polaris-tokens/compare/v2.2.0...HEAD
+[unreleased]: https://github.com/Shopify/polaris-tokens/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/Shopify/polaris-tokens/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Shopify/polaris-tokens/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/Shopify/polaris-tokens/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Shopify/polaris-tokens/compare/v2.0.0...v2.1.0

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ a {
 }
 
 // Using the map for a specific type of tokens (here: spacing)
-@import '~@shopify/polaris-tokens/dist/spacing.map';
+@import '~@shopify/polaris-tokens/dist/spacing.spacing-map';
 
 a {
-  color: map-get($polaris-spacing-map, 'spacing-loose');
+  color: map-get($polaris-spacing-map, 'loose');
 }
 ```
 

--- a/dist/spacing.spacing-map.scss
+++ b/dist/spacing.spacing-map.scss
@@ -1,0 +1,9 @@
+$polaris-spacing: (
+  'none': 0,
+  'extra-tight': 4px,
+  'tight': 8px,
+  'base-tight': 12px,
+  'base': 16px,
+  'loose': 20px,
+  'extra-loose': 32px,
+);

--- a/formats/spacing-map.scss.js
+++ b/formats/spacing-map.scss.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const Immutable = require('immutable');
+
+module.exports = (def) => {
+  const content = def
+    .get('props')
+    .map((prop) => {
+      let result = Immutable.List();
+      const key = prop.get('name').replace('spacing-', '');
+      const value = prop.get('value');
+      result = result.push(`  '${key}': ${value}`);
+      return result;
+    })
+    .flatten(1)
+    .toArray()
+    .join(',\n');
+  return `
+    $${path.basename(def.getIn(['meta', 'file']), '.yml')}: (
+      ${content}
+    );`;
+};


### PR DESCRIPTION
In Polaris, the [`available-names`](https://github.com/Shopify/polaris-react/blob/b65ad29ee3bb3c61ff7e038709078f2bf0c10af6/src/styles/foundation/utilities.scss#L70-L97) Sass function relies on prefix-less names when erroring out as a developer uses a non-existing name in their code.

For example: `spacing('fooooooo')` would throw something with:

```scss
@error 'Spacing variant `#{$variant}` not found. Available variants: #{available-names($spacing-data)}';
```

This means design tokens should output a map that doesn't have prefixes. By default, `spacing.map.scss` looks like this:

```scss
$polaris-spacing-map: (
  'spacing-none': (
    0,
  ),
  'spacing-extra-tight': (
    4px,
  ),
  'spacing-tight': (
    8px,
  ),
  'spacing-base-tight': (
    12px,
  ),
  'spacing-base': (
    16px,
  ),
  'spacing-loose': (
    20px,
  ),
  'spacing-extra-loose': (
    32px,
  ),
);
```

What we need [in this polaris-react PR](https://github.com/Shopify/polaris-react/pull/1056) is:

```scss
$polaris-spacing: (
  'none': 0,
  'extra-tight': 4px,
  'tight': 8px,
  'base-tight': 12px,
  'base': 16px,
  'loose': 20px,
  'extra-loose': 32px,
);
```

This PR is adding a new format: `spacing.spacing-map.scss` as seen above.