### PR TITLE
Color variant updates

### DIFF
--- a/formats/utils/color-factory/configs/base.js
+++ b/formats/utils/color-factory/configs/base.js
@@ -24,6 +24,13 @@ const base = {
       dark: {lightness: 10},
     },
     {
+      name: 'surfaceDisabled',
+      description:
+        'For use as a surface color on disabled interactive elements such as option list items and action list items when in a disabled state.',
+      light: {lightness: 98.3},
+      dark: {lightness: 10},
+    },
+    {
       name: 'surfaceHovered',
       description:
         'For use as a surface color on interactive elements such as resource list items and action list items when in a hovered state.',

--- a/formats/utils/color-factory/configs/base.js
+++ b/formats/utils/color-factory/configs/base.js
@@ -27,14 +27,14 @@ const base = {
       name: 'surfaceHovered',
       description:
         'For use as a surface color on interactive elements such as resource list items and action list items when in a hovered state.',
-      light: {lightness: 96},
+      light: {lightness: 95},
       dark: {lightness: 20},
     },
     {
       name: 'surfacePressed',
       description:
         'For use as a surface color on interactive elements such as resource list items and action list items when in a pressed state.',
-      light: {lightness: 90},
+      light: {lightness: 92},
       dark: {lightness: 27},
     },
     {
@@ -356,7 +356,7 @@ const base = {
       name: 'surfacePrimarySelected',
       description:
         'Used as a surface color to indicate selected interactive states in navigation and tabs.',
-      light: {lightness: 95, saturation: 30},
+      light: {lightness: 95, saturation: 20},
       dark: {lightness: 5, saturation: 30},
     },
     {
@@ -392,7 +392,7 @@ const base = {
     {
       name: 'iconCritical',
       description: 'For use as an icon fill color on top of critical elements.',
-      light: {lightness: 52},
+      light: {lightness: 47.3},
       dark: {lightness: 48},
     },
     {
@@ -509,7 +509,7 @@ const base = {
     {
       name: 'iconWarning',
       description: 'For use as an icon fill color on top of warning elements.',
-      light: {lightness: 66},
+      light: {lightness: 60},
       dark: {lightness: 34},
     },
     {

--- a/formats/utils/color-factory/configs/base.js
+++ b/formats/utils/color-factory/configs/base.js
@@ -270,7 +270,7 @@ const base = {
       description:
         'Used for secondary buttons and tertiary buttons, as well as in form elements as a background color and pontentially other secondary surfaces.',
       light: {lightness: 93},
-      dark: {lightness: 22},
+      dark: {lightness: 34},
     },
     {
       name: 'actionSecondaryDisabled',
@@ -700,7 +700,7 @@ const base = {
       light: {
         hue: hueRotationFn(87.5),
         saturation: saturationAdjustmentFn(-46),
-        lightness: 84,
+        lightness: 85,
       },
       dark: {
         hue: hueRotationFn(97.5),

--- a/formats/utils/color-factory/configs/base.js
+++ b/formats/utils/color-factory/configs/base.js
@@ -275,7 +275,7 @@ const base = {
     {
       name: 'actionSecondaryDisabled',
       description: 'Used as a disabled state for secondary buttons',
-      light: {lightness: 94},
+      light: {lightness: 95},
       dark: {lightness: 13},
     },
     {


### PR DESCRIPTION
https://github.com/Shopify/polaris-tokens/issues/100

### Updates
Adjust lightness of:

#### Surface
• surfaceHovered
• surfacePressed
• surfaceDisabled **`new`**
_Surface colors now match with Figma_

#### Secondary
• actionSecondaryDisabled

#### Primary
• surfacePrimarySelected
• actionPrimaryDisabled

#### Decorative
• decorativeThreeSurface

#### Critical
• actionDestructiveDisabled
• iconCritical

#### Warning
• iconWarning

---
ToDo
- [x] Update the surface-primary-selected color in GitHub
- [x] Update interaction state colors -> proposal colors in interaction state page
- [x] Add a surfaceDisabled variant (same lightness of the surfaceSubdued)