### PR TITLE
Add Figma metadata to config object

### DIFF
--- a/formats/figma.json.js
+++ b/formats/figma.json.js
@@ -1,0 +1,19 @@
+const tinycolor2 = require('tinycolor2');
+
+module.exports = (result) =>
+  JSON.stringify(
+    result.toJS().props.map((prop) => {
+      const {name, value, meta} = prop;
+
+      const returnValue = {
+        name,
+        value: tinycolor2(value).toRgb(),
+      };
+
+      if (meta && meta.figmaName) {
+        returnValue.figmaName = meta.figmaName;
+      }
+
+      return returnValue;
+    }),
+  );

--- a/formats/tokens.js
+++ b/formats/tokens.js
@@ -17,7 +17,11 @@ function tokenify(scheme) {
     const palette = colorFactory(theme, scheme, configArg);
 
     const yml = Object.entries(palette).reduce((accumulator, [key, value]) => {
-      return `${accumulator}  - name: ${key}\n    value: '${value}'\n`;
+      const figmaName = findFigmaName(configArg, key);
+
+      return `${accumulator}  - name: ${key}\n    value: '${value}'\n${figmaMetaData(
+        figmaName,
+      )}`;
     }, '');
 
     return `props:\n${yml}global:\n  type: color\n  category: background-color\n`;
@@ -32,6 +36,25 @@ function tokensToJson(data) {
     }),
     {},
   );
+}
+
+function figmaMetaData(name) {
+  return name == null ? '' : `    meta:\n      figmaName: ${name}\n`;
+}
+
+function findFigmaName(config, key) {
+  if (config == null) return null;
+
+  let returnValue;
+  Object.values(config).forEach((variants) => {
+    const found = variants.find((variant) => variant.name === key);
+
+    if (found && found.meta && found.meta.figmaName) {
+      returnValue = found.meta.figmaName;
+    }
+  });
+
+  return returnValue;
 }
 
 module.exports = {tokenify};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,6 +80,7 @@ const {tokenify} = require('./formats/tokens');
 theo.registerTransform('theme', ['color/hex']);
 theo.registerFormat('light.yml', tokenify('light'));
 theo.registerFormat('dark.yml', tokenify('dark'));
+theo.registerFormat('figma.json', require('./formats/figma.json.js'));
 
 const colorSchemes = [
   {transformType: 'raw', formatType: 'light.yml'},
@@ -90,6 +91,7 @@ const colorSystemFormats = [
   {transformType: 'web/js', formatType: 'json'},
   {transformType: 'android', formatType: 'android.xml'},
   {transformType: 'ios', formatType: 'ios.json'},
+  {transformType: 'raw', formatType: 'figma.json'},
 ];
 
 gulp.task('themes', (done) => {
@@ -125,7 +127,7 @@ gulp.task('palettes', (done) => {
           .pipe($.rename(addPrefix))
           .pipe(
             $.theo({
-              transform: {type: transformType},
+              transform: {type: transformType, includeMeta: true},
               format: {type: formatType},
             }),
           )

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -29,6 +29,9 @@ export const config: Config = {
         'For use as a subdued background color, in components such as Card, Modal, and Popover.',
       light: {lightness: 98.3},
       dark: {lightness: 10},
+      meta: {
+        figmaName: 'Surface/Subdued',
+      },
     },
     {
       name: 'surfaceDisabled',
@@ -36,6 +39,9 @@ export const config: Config = {
         'For use as a surface color on disabled interactive elements such as option list items and action list items when in a disabled state.',
       light: {lightness: 98.3},
       dark: {lightness: 10},
+      meta: {
+        figmaName: 'Surface/Disabled',
+      },
     },
     {
       name: 'surfaceHovered',
@@ -43,6 +49,9 @@ export const config: Config = {
         'For use as a surface color on interactive elements such as resource list items and action list items when in a hovered state.',
       light: {lightness: 95},
       dark: {lightness: 20},
+      meta: {
+        figmaName: 'Surface/Hovered',
+      },
     },
     {
       name: 'surfacePressed',
@@ -50,6 +59,9 @@ export const config: Config = {
         'For use as a surface color on interactive elements such as resource list items and action list items when in a pressed state.',
       light: {lightness: 92},
       dark: {lightness: 27},
+      meta: {
+        figmaName: 'Surface/Pressed',
+      },
     },
     {
       name: 'backdrop',
@@ -155,60 +167,90 @@ export const config: Config = {
       description: 'For use as a border on non-interactive elements.',
       light: {lightness: 60},
       dark: {lightness: 35},
+      meta: {
+        figmaName: 'Border/Default',
+      },
     },
     {
       name: 'borderSubdued',
       description: 'For use as a subdued border on non-interactive elements.',
       light: {lightness: 90},
       dark: {lightness: 32},
+      meta: {
+        figmaName: 'Border/Subdued',
+      },
     },
     {
       name: 'icon',
       description: 'For use as the fill color of icons.',
       light: {lightness: 40.1},
       dark: {lightness: 70.1},
+      meta: {
+        figmaName: 'Icon/Default',
+      },
     },
     {
       name: 'iconHovered',
       description: 'For use as the fill color of hovered icons.',
       light: {lightness: 10},
       dark: {lightness: 90},
+      meta: {
+        figmaName: 'Icon/Hovered',
+      },
     },
     {
       name: 'iconPressed',
       description: 'For use as the fill color of pressed icons.',
       light: {lightness: 30},
       dark: {lightness: 70},
+      meta: {
+        figmaName: 'Icon/Pressed',
+      },
     },
     {
       name: 'iconDisabled',
       description: 'For use as the fill color of disabled icons.',
       light: {lightness: 76.9},
       dark: {lightness: 36.8},
+      meta: {
+        figmaName: 'Icon/Disabled',
+      },
     },
     {
       name: 'iconSubdued',
       description: 'For use as the fill color of subdued icons.',
       light: {lightness: 59.8},
       dark: {lightness: 52.1},
+      meta: {
+        figmaName: 'Icon/Subdued',
+      },
     },
     {
       name: 'text',
       description: 'For use as a text color.',
       light: {lightness: 13.1},
       dark: {lightness: 90.8},
+      meta: {
+        figmaName: 'Text/Default',
+      },
     },
     {
       name: 'textDisabled',
       description: 'For use as a disabled text color.',
       light: {lightness: 60},
       dark: {lightness: 48.2},
+      meta: {
+        figmaName: 'Text/Disabled',
+      },
     },
     {
       name: 'textSubdued',
       description: 'For use as a subdued text color.',
       light: {lightness: 47.4},
       dark: {lightness: 65.1},
+      meta: {
+        figmaName: 'Text/Subdued',
+      },
     },
   ],
   interactive: [
@@ -222,6 +264,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(11.2),
         hue: hueRotationFn(-7.1),
       },
+      meta: {
+        figmaName: 'Interactive/Default',
+      },
     },
     {
       name: 'interactiveDisabled',
@@ -229,6 +274,9 @@ export const config: Config = {
       light: {lightness: 78, saturation: 17},
       dark: {
         lightness: 42,
+      },
+      meta: {
+        figmaName: 'Interactive/Disabled',
       },
     },
     {
@@ -240,6 +288,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(11.2),
         hue: hueRotationFn(-7.1),
       },
+      meta: {
+        figmaName: 'Interactive/Hovered',
+      },
     },
     {
       name: 'interactivePressed',
@@ -250,12 +301,18 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(11.2),
         hue: hueRotationFn(-7.1),
       },
+      meta: {
+        figmaName: 'Interactive/Pressed',
+      },
     },
     {
       name: 'focused',
       description: 'For use in the focus ring on interactive elements.',
       light: {lightness: 60, saturation: 100},
       dark: {lightness: 42},
+      meta: {
+        figmaName: 'Focused/Default',
+      },
     },
     {
       name: 'surfaceSelected',
@@ -263,6 +320,9 @@ export const config: Config = {
         'For use as a surface color in selected interactive elements, in components such as action list and resource list.',
       light: {lightness: 97, hue: hueRotationFn(-12)},
       dark: {lightness: 4},
+      meta: {
+        figmaName: 'Surface Selected/Default',
+      },
     },
     {
       name: 'surfaceSelectedHovered',
@@ -270,6 +330,9 @@ export const config: Config = {
         'For use as a surface color in selected interactive elements that are hovered, in components such as action list and resource list.',
       light: {lightness: 96, hue: hueRotationFn(-12)},
       dark: {lightness: 11},
+      meta: {
+        figmaName: 'Surface Selected/Hovered',
+      },
     },
     {
       name: 'surfaceSelectedPressed',
@@ -277,18 +340,27 @@ export const config: Config = {
         'For use as a surface color in selected interactive elements that are pressed, in components such as action list and resource list.',
       light: {lightness: 94, hue: hueRotationFn(-10)},
       dark: {lightness: 18},
+      meta: {
+        figmaName: 'Surface Selected/Pressed',
+      },
     },
     {
       name: 'iconOnInteractive',
       description: 'For use as a fill color for icons on interactive elements.',
       light: {lightness: 100},
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Icon On/Interactive',
+      },
     },
     {
       name: 'textOnInteractive',
       description: 'For use as a text color on interactive elements.',
       light: {lightness: 100},
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Text On/Interactive',
+      },
     },
   ],
   secondary: [
@@ -298,42 +370,63 @@ export const config: Config = {
         'Used for secondary buttons and tertiary buttons, as well as in form elements as a background color and pontentially other secondary surfaces.',
       light: {lightness: 93},
       dark: {lightness: 34},
+      meta: {
+        figmaName: 'Action Secondary/Default',
+      },
     },
     {
       name: 'actionSecondaryDisabled',
       description: 'Used as a disabled state for secondary buttons',
       light: {lightness: 95},
       dark: {lightness: 13},
+      meta: {
+        figmaName: 'Action Secondary/Disabled',
+      },
     },
     {
       name: 'actionSecondaryHovered',
       description: 'Used as a hovered state for secondary buttons',
       light: {lightness: 90},
       dark: {lightness: 37},
+      meta: {
+        figmaName: 'Action Secondary/Hovered',
+      },
     },
     {
       name: 'actionSecondaryPressed',
       description: 'Used as a pressed state for secondary buttons',
       light: {lightness: 87},
       dark: {lightness: 42},
+      meta: {
+        figmaName: 'Action Secondary/Pressed',
+      },
     },
     {
       name: 'borderSecondary',
       description: 'Used for borders on form elements',
       light: {lightness: 75},
       dark: {lightness: 35},
+      meta: {
+        figmaName: 'Border Secondary/Default',
+      },
     },
     {
       name: 'borderSecondaryHovered',
       description: 'Used for borders on hovered form elements',
       light: {lightness: 65},
       dark: {lightness: 35},
+      meta: {
+        figmaName: 'Border Secondary/Hovered',
+      },
     },
     {
       name: 'borderSecondaryDisabled',
       description: 'Used for disabled borders on form elements',
       light: {lightness: 85},
       dark: {lightness: 45},
+      meta: {
+        figmaName: 'Border Secondary/Disabled',
+      },
     },
   ],
   primary: [
@@ -343,6 +436,9 @@ export const config: Config = {
         'Used as the background color for primary actions, and as the fill color for icons and the text color in navigation and tabs to communicate interaction states.',
       light: {lightness: 47.3},
       dark: {lightness: 47.3},
+      meta: {
+        figmaName: 'Action Primary/Default',
+      },
     },
     {
       name: 'actionPrimaryDisabled',
@@ -350,6 +446,9 @@ export const config: Config = {
         'Used as the background color for disabled primary actions, and as the fill color for icons and the text color in navigation and tabs to communicate interaction states.',
       light: {lightness: 95, saturation: 0},
       dark: {lightness: 32},
+      meta: {
+        figmaName: 'Action Primary/Disabled',
+      },
     },
     {
       name: 'actionPrimaryHovered',
@@ -357,6 +456,9 @@ export const config: Config = {
         'Used as the background color for hovered primary actions, and as the fill color for icons and the text color in navigation and tabs to communicate interaction states.',
       light: {lightness: 41, saturation: 100},
       dark: {lightness: 55},
+      meta: {
+        figmaName: 'Action Primary/Hovered',
+      },
     },
     {
       name: 'actionPrimaryPressed',
@@ -364,6 +466,9 @@ export const config: Config = {
         'Used as the background color for pressed primary actions, and as the fill color for icons and the text color in navigation and tabs to communicate interaction states.',
       light: {lightness: 35, saturation: 100},
       dark: {lightness: 60},
+      meta: {
+        figmaName: 'Action Primary/Pressed',
+      },
     },
     {
       name: 'iconOnPrimary',
@@ -371,6 +476,9 @@ export const config: Config = {
         'For use as a fill color for icons on primary actions. Not for use in icons on navigation and tabs.',
       light: {lightness: 100},
       dark: {lightness: 98},
+      meta: {
+        figmaName: 'Icon On/Primary',
+      },
     },
     {
       name: 'textOnPrimary',
@@ -378,6 +486,9 @@ export const config: Config = {
         'For use as a text color on primary actions. Not for use in text on navigation and tabs.',
       light: {lightness: 100},
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Text On/Primary',
+      },
     },
     {
       name: 'surfacePrimarySelected',
@@ -385,6 +496,9 @@ export const config: Config = {
         'Used as a surface color to indicate selected interactive states in navigation and tabs.',
       light: {lightness: 95, saturation: 20},
       dark: {lightness: 5, saturation: 30},
+      meta: {
+        figmaName: 'Surface Primary/Selected',
+      },
     },
     {
       name: 'surfacePrimarySelectedHovered',
@@ -392,6 +506,9 @@ export const config: Config = {
         'Used as a surface color to indicate selected interactive states that are hovered in navigation and tabs.',
       light: {lightness: 81, saturation: 22},
       dark: {lightness: 19, saturation: 22},
+      meta: {
+        figmaName: 'Surface Primary/Selected Hovered',
+      },
     },
     {
       name: 'surfacePrimarySelectedPressed',
@@ -399,6 +516,9 @@ export const config: Config = {
         'Used as a surface color to indicate selected interactive states that are pressed in navigation and tabs.',
       light: {lightness: 74, saturation: 22},
       dark: {lightness: 26, saturation: 22},
+      meta: {
+        figmaName: 'Surface Primary/Selected Pressed',
+      },
     },
   ],
   critical: [
@@ -408,6 +528,9 @@ export const config: Config = {
         'For use as a border on critical components such as banners, and as an outline on interactive elements in an error state.',
       light: {lightness: 50},
       dark: {lightness: 50},
+      meta: {
+        figmaName: 'Border Critical/Default',
+      },
     },
     {
       name: 'borderCriticalDisabled',
@@ -415,12 +538,18 @@ export const config: Config = {
         'For use as a disabled border on critical components such as banners, and as an outline on interactive elements in an error state.',
       light: {lightness: 77, saturation: 100},
       dark: {lightness: 28},
+      meta: {
+        figmaName: 'Border Critical/Disabled',
+      },
     },
     {
       name: 'iconCritical',
       description: 'For use as an icon fill color on top of critical elements.',
       light: {lightness: 47.3},
       dark: {lightness: 48},
+      meta: {
+        figmaName: 'Icon/Critical',
+      },
     },
     {
       name: 'surfaceCritical',
@@ -428,6 +557,9 @@ export const config: Config = {
         'For use as a surface color on critical elements including badges.',
       light: {lightness: 88},
       dark: {lightness: 12},
+      meta: {
+        figmaName: 'Surface Critical/Default',
+      },
     },
     {
       name: 'surfaceCriticalSubdued',
@@ -435,6 +567,9 @@ export const config: Config = {
         'For use as a subdued surface color on critical elements including banners.',
       light: {lightness: 97},
       dark: {lightness: 12},
+      meta: {
+        figmaName: 'Surface Critical/Subdued',
+      },
     },
     {
       name: 'surfaceCriticalSubduedHovered',
@@ -442,6 +577,10 @@ export const config: Config = {
         'For use as a surface color on critical interactive elements including action list items in a hovered state.',
       light: {lightness: 96},
       dark: {lightness: 15, saturation: 60},
+      meta: {
+        figmaName: 'Surface Critical/Subdued Hovered',
+        figmaDescription: 'Used on action lists',
+      },
     },
     {
       name: 'surfaceCriticalSubduedPressed',
@@ -449,6 +588,9 @@ export const config: Config = {
         'For use as a surface color on critical interactive elements including action list items in a pressed state.',
       light: {lightness: 94},
       dark: {lightness: 22},
+      meta: {
+        figmaName: 'Surface Critical/Subdued Pressed',
+      },
     },
     {
       name: 'textCritical',
@@ -456,6 +598,9 @@ export const config: Config = {
         'For use as a text color in inert critical elements such as exception list. Not for use as a text color on banners and badges.',
       light: {lightness: 47.3},
       dark: {lightness: 65, saturation: 70},
+      meta: {
+        figmaName: 'Text/Critical',
+      },
     },
     {
       name: 'actionCritical',
@@ -463,6 +608,9 @@ export const config: Config = {
         'For use as the background color for destructive buttons, and as the background color for error toast messages.',
       light: {lightness: 47.5},
       dark: {lightness: 45},
+      meta: {
+        figmaName: 'Action Critical/Default',
+      },
     },
     {
       name: 'actionCriticalDisabled',
@@ -470,6 +618,9 @@ export const config: Config = {
         'For use as the background color for disabled destructive buttons, and as the background color for error toast messages.',
       light: {lightness: 95, saturation: 0},
       dark: {lightness: 41},
+      meta: {
+        figmaName: 'Action Critical/Disabled',
+      },
     },
     {
       name: 'actionCriticalHovered',
@@ -477,6 +628,9 @@ export const config: Config = {
         'For use as the background color for hovered destructive buttons, and as the background color for error toast messages.',
       light: {lightness: 41, saturation: 100},
       dark: {lightness: 50},
+      meta: {
+        figmaName: 'Action Critical/Hovered',
+      },
     },
     {
       name: 'actionCriticalPressed',
@@ -484,18 +638,27 @@ export const config: Config = {
         'For use as the background color for pressed destructive buttons, and as the background color for error toast messages.',
       light: {lightness: 35, saturation: 100},
       dark: {lightness: 55},
+      meta: {
+        figmaName: 'Action Critical/Pressed',
+      },
     },
     {
       name: 'iconOnCritical',
       description: 'For use as a fill color for icons on critical actions.',
       light: {lightness: 100},
       dark: {lightness: 98},
+      meta: {
+        figmaName: 'Icon On/Critical',
+      },
     },
     {
       name: 'textOnCritical',
       description: 'For use as a text color on critical actions.',
       light: {lightness: 100},
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Text On/Critical',
+      },
     },
     {
       name: 'interactiveCritical',
@@ -503,6 +666,9 @@ export const config: Config = {
         'For use as the text color for destructive interactive elements: links, plain buttons, error state of selected checkboxes and radio buttons, as well as a text color on destructive action list items. Not for use on critical banners and badges.',
       light: {lightness: 47.5},
       dark: {lightness: 65},
+      meta: {
+        figmaName: 'Interactive/Critical',
+      },
     },
     {
       name: 'interactiveCriticalDisabled',
@@ -510,6 +676,9 @@ export const config: Config = {
         'For use as a text color in disabled destructive plain buttons, as well as a text color on destructive action list items. Not for use on critical banners and badges.',
       light: {lightness: 72},
       dark: {lightness: 78},
+      meta: {
+        figmaName: 'Interactive/Critical Disabled',
+      },
     },
     {
       name: 'interactiveCriticalHovered',
@@ -517,6 +686,9 @@ export const config: Config = {
         'For use as a text color in hovered destructive plain buttons, as well as a text color on destructive action list items. Not for use on critical banners and badges.',
       light: {lightness: 45},
       dark: {lightness: 70},
+      meta: {
+        figmaName: 'Interactive/Critical Hovered',
+      },
     },
     {
       name: 'interactiveCriticalPressed',
@@ -524,6 +696,9 @@ export const config: Config = {
         'For use as a text color in pressed destructive plain buttons, as well as a text color on destructive action list items. Not for use on critical banners and badges.',
       light: {lightness: 21},
       dark: {lightness: 75},
+      meta: {
+        figmaName: 'Interactive/Critical Pressed',
+      },
     },
   ],
   warning: [
@@ -532,12 +707,18 @@ export const config: Config = {
       description: 'For use as a border on warning components such as banners.',
       light: {lightness: 77, saturation: 60},
       dark: {lightness: 50},
+      meta: {
+        figmaName: 'Border Warning/Default',
+      },
     },
     {
       name: 'iconWarning',
       description: 'For use as an icon fill color on top of warning elements.',
       light: {lightness: 60},
       dark: {lightness: 34},
+      meta: {
+        figmaName: 'Icon/Warning',
+      },
     },
     {
       name: 'surfaceWarning',
@@ -556,6 +737,10 @@ export const config: Config = {
         'For use as a subdued surface color on warning elements including banners.',
       light: {lightness: 97},
       dark: {lightness: 26, saturation: 71},
+      meta: {
+        figmaName: 'Surface Warning/Subdued',
+        figmaDescription: 'Used for banners',
+      },
     },
     {
       name: 'textWarning',
@@ -563,6 +748,9 @@ export const config: Config = {
         'For use as a text color in inert critical elements such as exception list. Not for use as a text color on banners and badges.',
       light: {lightness: 47.4},
       dark: {lightness: 64.9},
+      meta: {
+        figmaName: 'Text/Warning',
+      },
     },
   ],
   highlight: [
@@ -572,6 +760,9 @@ export const config: Config = {
         'For use as a border on informational components such as banners.',
       light: {lightness: 60, saturation: 100},
       dark: {lightness: 60},
+      meta: {
+        figmaName: 'Border Highlight/Default',
+      },
     },
     {
       name: 'iconHighlight',
@@ -579,6 +770,9 @@ export const config: Config = {
         'For use as an icon fill color on top of informational elements.',
       light: {lightness: 60, saturation: 100},
       dark: {lightness: 42},
+      meta: {
+        figmaName: 'Icon/Highlight',
+      },
     },
     {
       name: 'surfaceHighlight',
@@ -586,6 +780,9 @@ export const config: Config = {
         'For use as a surface color on information elements including badges.',
       light: {lightness: 88, saturation: 60},
       dark: {lightness: 40, saturation: 100},
+      meta: {
+        figmaName: 'Surface Highlight/Default',
+      },
     },
     {
       name: 'surfaceHighlightSubdued',
@@ -593,6 +790,9 @@ export const config: Config = {
         'For use as a surface color on information elements including banners.',
       light: {lightness: 97, saturation: 60},
       dark: {lightness: 20},
+      meta: {
+        figmaName: 'Surface Highlight/Subdued',
+      },
     },
     {
       name: 'textHighlight',
@@ -600,6 +800,9 @@ export const config: Config = {
         'For use as a text color in inert informational elements. Not for use as a text color on banners and badges.',
       light: {lightness: 48},
       dark: {lightness: 90},
+      meta: {
+        figmaName: 'Text/Highlight',
+      },
     },
   ],
   success: [
@@ -608,12 +811,18 @@ export const config: Config = {
       description: 'For use as a border on success components such as banners.',
       light: {lightness: 77, saturation: 40},
       dark: {lightness: 50},
+      meta: {
+        figmaName: 'Border Success/Default',
+      },
     },
     {
       name: 'iconSuccess',
       description: 'For use as an icon fill color on top of success elements.',
       light: {lightness: 47},
       dark: {lightness: 35},
+      meta: {
+        figmaName: 'Icon/Success',
+      },
     },
     {
       name: 'surfaceSuccess',
@@ -621,6 +830,9 @@ export const config: Config = {
         'For use as a surface color on success elements including badges.',
       light: {lightness: 88, saturation: 40},
       dark: {lightness: 35},
+      meta: {
+        figmaName: 'Surface Success/Default',
+      },
     },
     {
       name: 'surfaceSuccessSubdued',
@@ -628,6 +840,9 @@ export const config: Config = {
         'For use as a surface color on information elements including banners.',
       light: {lightness: 97, saturation: 20},
       dark: {lightness: 20, saturation: 60},
+      meta: {
+        figmaName: 'Surface Success/Subdued',
+      },
     },
     {
       name: 'textSuccess',
@@ -635,6 +850,9 @@ export const config: Config = {
         'For use as a text color in inert success elements. Not for use as a text color on banners and badges.',
       light: {lightness: 47.3},
       dark: {lightness: 65, saturation: 70},
+      meta: {
+        figmaName: 'Text/Success',
+      },
     },
   ],
   decorative: [
@@ -650,6 +868,9 @@ export const config: Config = {
         hue: hueRotationFn(-4.5),
         lightness: 80,
       },
+      meta: {
+        figmaName: 'Decorative/Icon/One',
+      },
     },
     {
       name: 'decorativeOneSurface',
@@ -662,6 +883,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-2),
         lightness: 46,
       },
+      meta: {
+        figmaName: 'Decorative/Surface/One',
+      },
     },
     {
       name: 'decorativeOneText',
@@ -672,6 +896,9 @@ export const config: Config = {
         lightness: 18,
       },
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Decorative/Text/One',
+      },
     },
     {
       name: 'decorativeTwoIcon',
@@ -687,6 +914,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-20),
         lightness: 80,
       },
+      meta: {
+        figmaName: 'Decorative/Icon/Two',
+      },
     },
     {
       name: 'decorativeTwoSurface',
@@ -700,6 +930,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-4),
         lightness: 52,
       },
+      meta: {
+        figmaName: 'Decorative/Surface/Two',
+      },
     },
     {
       name: 'decorativeTwoText',
@@ -711,6 +944,9 @@ export const config: Config = {
         lightness: 14,
       },
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Decorative/Text/Two',
+      },
     },
     {
       name: 'decorativeThreeIcon',
@@ -723,6 +959,9 @@ export const config: Config = {
       dark: {
         hue: hueRotationFn(87.5),
         lightness: 80,
+      },
+      meta: {
+        figmaName: 'Decorative/Icon/Three',
       },
     },
     {
@@ -737,6 +976,9 @@ export const config: Config = {
         hue: hueRotationFn(97.5),
         lightness: 46,
       },
+      meta: {
+        figmaName: 'Decorative/Surface/Three',
+      },
     },
     {
       name: 'decorativeThreeText',
@@ -747,6 +989,9 @@ export const config: Config = {
         lightness: 16,
       },
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Decorative/Text/Three',
+      },
     },
     {
       name: 'decorativeFourIcon',
@@ -759,6 +1004,9 @@ export const config: Config = {
       dark: {
         hue: hueRotationFn(133.5),
         lightness: 80,
+      },
+      meta: {
+        figmaName: 'Decorative/Icon/Four',
       },
     },
     {
@@ -774,6 +1022,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-5),
         lightness: 47,
       },
+      meta: {
+        figmaName: 'Decorative/Surface/Four',
+      },
     },
     {
       name: 'decorativeFourText',
@@ -784,6 +1035,9 @@ export const config: Config = {
         lightness: 16,
       },
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Decorative/Text/Four',
+      },
     },
     {
       name: 'decorativeFiveIcon',
@@ -799,6 +1053,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-22),
         lightness: 80,
       },
+      meta: {
+        figmaName: 'Decorative/Icon/Five',
+      },
     },
     {
       name: 'decorativeFiveSurface',
@@ -813,6 +1070,9 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-23),
         lightness: 45,
       },
+      meta: {
+        figmaName: 'Decorative/Surface/Five',
+      },
     },
     {
       name: 'decorativeFiveText',
@@ -824,6 +1084,9 @@ export const config: Config = {
         lightness: 16,
       },
       dark: {lightness: 100},
+      meta: {
+        figmaName: 'Decorative/Text/Five',
+      },
     },
   ],
 };

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -9,6 +9,9 @@ export const config: Config = {
         'For use as a background color, in components such as Page and Frame backgrounds.',
       light: {lightness: 98.3},
       dark: {lightness: 3.3},
+      meta: {
+        figmaName: 'Background/Default',
+      },
     },
     {
       name: 'surface',
@@ -16,6 +19,9 @@ export const config: Config = {
         'For use as a background color, in components such as Card, Modal, and Popover.',
       light: {lightness: 100},
       dark: {lightness: 12.7},
+      meta: {
+        figmaName: 'Surface/Default',
+      },
     },
     {
       name: 'surfaceSubdued',
@@ -539,6 +545,10 @@ export const config: Config = {
         'For use as a surface color on warning elements including badges.',
       light: {lightness: 88},
       dark: {lightness: 50},
+      meta: {
+        figmaName: 'Surface Warning/Deafult',
+        figmaDescription: 'Use for badges',
+      },
     },
     {
       name: 'surfaceWarningSubdued',

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -546,7 +546,7 @@ export const config: Config = {
       light: {lightness: 88},
       dark: {lightness: 50},
       meta: {
-        figmaName: 'Surface Warning/Deafult',
+        figmaName: 'Surface Warning/Default',
         figmaDescription: 'Use for badges',
       },
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ export interface Variant {
   description?: string;
   light: HslaSetting;
   dark: HslaSetting;
+  meta?: {
+    figmaName?: string;
+    figmaDescription?: string;
+  };
 }
 
 export type Config = Record<string, Variant[]>;


### PR DESCRIPTION
The Figma sync is now working well. To make it happen, I created an object with name mappings for all the variants:

```
const colorMapping = [
  {
    "github": "background",
    "figma": "Background/Default"
  },...
```

This information should probably live in polaris-tokens, so that anyone can access the data and build their own plugins.

This draft PR shows an example of how the config object could be extended. Thoughts on the format?