### PR TITLE
Remove borderSecondary variants and update border onSurface variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Remove `borderSecondary` variants and update border `onSurface` variants ([#115](https://github.com/Shopify/polaris-tokens/pull/115))
 
 ## [2.9.0] - 2020-03-03
 

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -164,7 +164,7 @@ export const config: Config = {
   onSurface: [
     {
       name: 'border',
-      description: 'For use as a border on non-interactive elements.',
+      description: 'For use as the default border on elements.',
       light: {lightness: 60},
       dark: {lightness: 35},
       meta: {
@@ -172,8 +172,26 @@ export const config: Config = {
       },
     },
     {
+      name: 'borderHovered',
+      description: 'Used for borders on hovered interactive elements',
+      light: {lightness: 65},
+      dark: {lightness: 35},
+      meta: {
+        figmaName: 'Border/Hovered',
+      },
+    },
+    {
+      name: 'borderDisabled',
+      description: 'Used for disabled borders on interactive elements',
+      light: {lightness: 85},
+      dark: {lightness: 45},
+      meta: {
+        figmaName: 'Border/Disabled',
+      },
+    },
+    {
       name: 'borderSubdued',
-      description: 'For use as a subdued border on non-interactive elements.',
+      description: 'For use as a secondary border on elements.',
       light: {lightness: 90},
       dark: {lightness: 32},
       meta: {
@@ -399,33 +417,6 @@ export const config: Config = {
       dark: {lightness: 42},
       meta: {
         figmaName: 'Action Secondary/Pressed',
-      },
-    },
-    {
-      name: 'borderSecondary',
-      description: 'Used for borders on form elements',
-      light: {lightness: 75},
-      dark: {lightness: 35},
-      meta: {
-        figmaName: 'Border Secondary/Default',
-      },
-    },
-    {
-      name: 'borderSecondaryHovered',
-      description: 'Used for borders on hovered form elements',
-      light: {lightness: 65},
-      dark: {lightness: 35},
-      meta: {
-        figmaName: 'Border Secondary/Hovered',
-      },
-    },
-    {
-      name: 'borderSecondaryDisabled',
-      description: 'Used for disabled borders on form elements',
-      light: {lightness: 85},
-      dark: {lightness: 45},
-      meta: {
-        figmaName: 'Border Secondary/Disabled',
       },
     },
   ],

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -191,7 +191,7 @@ export const config: Config = {
     },
     {
       name: 'borderSubdued',
-      description: 'For use as a secondary border on elements.',
+      description: 'For use as a subdued border on elements.',
       light: {lightness: 90},
       dark: {lightness: 32},
       meta: {


### PR DESCRIPTION
## Why

It was unclear when to use borderSecondary vs. the on surface border variants and there are no clear benefits to having both.

## What
This PR consolidates the two borders replacing borderSecondary with border.

Full details in [Slack thread](https://shopify.slack.com/archives/CTGNZSQ48/p1582749879050700)

---

**ToDo:**

- [x] open a pull request in polaris-tokens adding missing border variants to onSurface , and removing all border variants in secondary
- [ ] merge that pull request and cut a new release of polaris-tokens 
- [ ] open a pull request in polaris-react that bumps to this latest release, and removes all use of secondary borders in favor of on surface borders
- [ ] update Figma to be consistent with these changes