### PR TITLE
Remove interactiveCriticalDisabled variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Remove `interactiveCriticalDisabled` color variant, use `textDisabled` instead ([#116](https://github.com/Shopify/polaris-tokens/pull/116))
 
 ## [2.9.0] - 2020-03-03
 

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -671,16 +671,6 @@ export const config: Config = {
       },
     },
     {
-      name: 'interactiveCriticalDisabled',
-      description:
-        'For use as a text color in disabled destructive plain buttons, as well as a text color on destructive action list items. Not for use on critical banners and badges.',
-      light: {lightness: 72},
-      dark: {lightness: 78},
-      meta: {
-        figmaName: 'Interactive/Critical Disabled',
-      },
-    },
-    {
       name: 'interactiveCriticalHovered',
       description:
         'For use as a text color in hovered destructive plain buttons, as well as a text color on destructive action list items. Not for use on critical banners and badges.',


### PR DESCRIPTION
## Why

Disabled states are the same across elements regardless of status. We use `textDisabled` for the disabled state as well.

## What

This PR removes the `interactiveCriticalDisabled` variant

---

**ToDo:**

- [x] open a pull request in polaris-tokens adding missing border variants to onSurface , and removing all border variants in secondary
- [ ] merge that pull request and cut a new release of polaris-tokens 
- [ ] open a pull request in polaris-react that bumps to this latest release, and removes all use of secondary borders in favor of on surface borders
- [ ] update Figma to be consistent with these changes