### PR TITLE
[Color system] add missing variants

### DIFF
--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -64,6 +64,16 @@ export const config: Config = {
       },
     },
     {
+      name: 'surfaceDepressed',
+      description:
+        'For use as a surface color on interactive elements such as resource list items and action list items when in a depressed state.',
+      light: {lightness: 62},
+      dark: {lightness: 35},
+      meta: {
+        figmaName: 'Surface/Depressed',
+      },
+    },
+    {
       name: 'backdrop',
       description:
         'For use as the background color of the backdrop component for navigation and modal. This color has an alpha of `0.5`.',
@@ -417,6 +427,15 @@ export const config: Config = {
       dark: {lightness: 42},
       meta: {
         figmaName: 'Action Secondary/Pressed',
+      },
+    },
+    {
+      name: 'actionSecondaryDepressed',
+      description: 'Used as a depressed state for secondary buttons',
+      light: {lightness: 48},
+      dark: {lightness: 47},
+      meta: {
+        figmaName: 'Action Secondary/Depressed',
       },
     },
   ],

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -24,6 +24,24 @@ export const config: Config = {
       },
     },
     {
+      name: 'surfaceNeutral',
+      description: 'For use as a background color in neutral badges.',
+      light: {lightness: 91},
+      dark: {lightness: 21},
+      meta: {
+        figmaName: 'SurfaceNeutral/Default',
+      },
+    },
+    {
+      name: 'surfaceNeutralSubdued',
+      description: 'For use as a background color in neutral banners.',
+      light: {lightness: 97},
+      dark: {lightness: 30},
+      meta: {
+        figmaName: 'SurfaceNeutral/Subdued',
+      },
+    },
+    {
       name: 'surfaceSubdued',
       description:
         'For use as a subdued background color, in components such as Card, Modal, and Popover.',
@@ -481,6 +499,16 @@ export const config: Config = {
       },
     },
     {
+      name: 'actionPrimaryDepressed',
+      description:
+        'Used as the background color for pressed primary actions, and as the fill color for icons and the text color in navigation and tabs to communicate interaction states.',
+      light: {lightness: 22},
+      dark: {lightness: 65},
+      meta: {
+        figmaName: 'Action Primary/Depressed',
+      },
+    },
+    {
       name: 'iconOnPrimary',
       description:
         'For use as a fill color for icons on primary actions. Not for use in icons on navigation and tabs.',
@@ -603,6 +631,16 @@ export const config: Config = {
       },
     },
     {
+      name: 'surfaceCriticalSubduedDeressed',
+      description:
+        'For use as a surface color on critical interactive elements including action list items in a depressed state.',
+      light: {lightness: 82},
+      dark: {lightness: 29},
+      meta: {
+        figmaName: 'Surface Critical/Subdued Depressed',
+      },
+    },
+    {
       name: 'textCritical',
       description:
         'For use as a text color in inert critical elements such as exception list. Not for use as a text color on banners and badges.',
@@ -650,6 +688,16 @@ export const config: Config = {
       dark: {lightness: 55},
       meta: {
         figmaName: 'Action Critical/Pressed',
+      },
+    },
+    {
+      name: 'actionCriticalDepressed',
+      description:
+        'For use as the background color for depressed destructive buttons, and as the background color for error toast messages.',
+      light: {lightness: 22, saturation: saturationAdjustmentFn(2.7)},
+      dark: {lightness: 60},
+      meta: {
+        figmaName: 'Action Critical/Depressed',
       },
     },
     {

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -631,7 +631,7 @@ export const config: Config = {
       },
     },
     {
-      name: 'surfaceCriticalSubduedDeressed',
+      name: 'surfaceCriticalSubduedDepressed',
       description:
         'For use as a surface color on critical interactive elements including action list items in a depressed state.',
       light: {lightness: 82},


### PR DESCRIPTION
This adds neutral surface variants
- surfaceNeutral (badge)
- surfaceNeutralSubdued (banner)

And depressed variants for buttons
- surfaceDepressed (outline button depressed state)
- actionSecondaryDepressed (secondary button depressed state)
- actionPrimaryDepressed (primary depressed state)
- surfaceCriticalSubduedDepressed (critical action list item depressed state, critical outline button depressed state)
- actionCriticalDepressed (critical button depressed state)

All light color scheme lightness configs are based on figma. Dark color scheme lightness configs were best guesses based on perceived patterns, and can be updated when we focus on dark mode.

**Updated in color systems spreadsheet:** https://docs.google.com/spreadsheets/d/1VtebqhKrVD9l90O4veYFcH86D9xiZxeuSt-IWTew6yc/edit#gid=568251708