### PR TITLE
Update description for textDisabled

### DIFF
--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -309,7 +309,8 @@ export const config: Config = {
     },
     {
       name: 'textDisabled',
-      description: 'For use as a disabled text color.',
+      description:
+        'For use as a disabled text color and as placeholder text in text fields.',
       light: {lightness: 60},
       dark: {lightness: 48.2},
       meta: {

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -310,7 +310,7 @@ export const config: Config = {
     {
       name: 'textDisabled',
       description:
-        'For use as a disabled text color and as placeholder text in text fields.',
+        'For use as a disabled text color and as a placeholder text color in text fields.',
       light: {lightness: 60},
       dark: {lightness: 48.2},
       meta: {

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -310,7 +310,7 @@ export const config: Config = {
     {
       name: 'textDisabled',
       description:
-        'For use as a disabled text color and as a placeholder text color in text fields.',
+        'For use as a disabled text color and as a placeholder text color.',
       light: {lightness: 60},
       dark: {lightness: 48.2},
       meta: {


### PR DESCRIPTION
The UI kit uses `textDisabled` for text input placeholders. I added this info to the token's description.

Additionally, do anyone think it's worth adding a dedicated token for placeholder text? [Slack discussion](https://shopify.slack.com/archives/CTGNZSQ48/p1584642476005900?thread_ts=1584034089.006000&cid=CTGNZSQ48)