### PR TITLE
Update font stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Updated the font stack so that Segoe UI comes before Roboto. ([#131](https://github.com/Shopify/polaris-tokens/pull/131))
 
 ## [2.12.1] - 2020-03-18
 

--- a/tests/__snapshots__/colors.test.ts.snap
+++ b/tests/__snapshots__/colors.test.ts.snap
@@ -750,7 +750,7 @@ exports[`Compare files snapshots renders index.d.ts as expected 1`] = `
   durationSlow: 300;
   durationSlower: 400;
   durationSlowest: 500;
-  fontStackBase: \\"-apple-system, BlinkMacSystemFont, 'San Francisco', Roboto, 'Segoe UI', 'Helvetica Neue', sans-serif\\";
+  fontStackBase: \\"-apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif\\";
   fontStackMonospace: \\"Monaco, Consolas, 'Lucida Console', monospace\\";
   spacingBase: \\"16px\\";
   spacingBaseTight: \\"12px\\";

--- a/tests/__snapshots__/duration.test.ts.snap
+++ b/tests/__snapshots__/duration.test.ts.snap
@@ -112,7 +112,7 @@ exports[`Compare files snapshots renders index.d.ts as expected 1`] = `
   durationSlow: 300;
   durationSlower: 400;
   durationSlowest: 500;
-  fontStackBase: \\"-apple-system, BlinkMacSystemFont, 'San Francisco', Roboto, 'Segoe UI', 'Helvetica Neue', sans-serif\\";
+  fontStackBase: \\"-apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif\\";
   fontStackMonospace: \\"Monaco, Consolas, 'Lucida Console', monospace\\";
   spacingBase: \\"16px\\";
   spacingBaseTight: \\"12px\\";

--- a/tokens/typography.yml
+++ b/tokens/typography.yml
@@ -1,7 +1,7 @@
 props:
   # Font stacks
   - name: font-stack-base
-    value: -apple-system, BlinkMacSystemFont, 'San Francisco', Roboto, 'Segoe UI', 'Helvetica Neue', sans-serif
+    value: -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif
     type: font-family
     category: font-family
   - name: font-stack-monospace


### PR DESCRIPTION
Bumps `Segoe UI`'s priority in the font stack, so that it comes before Roboto. This is a change that we're doing across Shopify, see [this](https://github.com/Shopify/polaris-react/pull/2891) and [this](https://github.com/Shopify/web/pull/25464).