### PR TITLE
Add action and icon to color filters map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add icon and action colors to color-filters-map ([#149](https://github.com/Shopify/polaris-tokens/pull/149))
+
 ## [2.12.7] - 2020-09-09
 
 - Updates the onSurface background name ([#147](https://github.com/Shopify/polaris-tokens/pull/147))

--- a/dist/color-filters.color-map.scss
+++ b/dist/color-filters.color-map.scss
@@ -137,4 +137,12 @@ $polaris-color-filters: (
   'white': (
     'base': brightness(0) saturate(100%) invert(100%),
   ),
+  'icon': (
+    'base': brightness(0) saturate(100%) invert(36%) sepia(13%) saturate(137%)
+      hue-rotate(169deg) brightness(95%) contrast(87%),
+  ),
+  'action': (
+    'base': brightness(0) saturate(100%) invert(20%) sepia(59%) saturate(5557%)
+      hue-rotate(162deg) brightness(95%) contrast(101%),
+  ),
 );


### PR DESCRIPTION
Part of https://github.com/Shopify/web/issues/30958

🎩 here https://codepen.io/kaelig/full/jeObGP/ with these values:

Action: `rgb(0, 128, 96)`

Icon: `rgb(92, 95, 98)`