### PR TITLE
Changing dark mode values for some subdued borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Changed dark mode values for some subdued borders ([#156](https://github.com/Shopify/polaris-tokens/pull/156))
+
 ## [2.13.1] - 2020-11-1
 
 - Moved mistaken border variants to surface variants ([#154](https://github.com/Shopify/polaris-tokens/pull/154))

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -260,7 +260,7 @@ export const config: Config = {
       name: 'borderNeutralSubdued',
       description: 'For use as the border on banners.',
       light: {lightness: 77},
-      dark: {lightness: 35},
+      dark: {lightness: 56},
       meta: {
         figmaName: 'Border Neutral/Subdued',
       },
@@ -290,10 +290,7 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-1),
         lightness: 81.9,
       },
-      dark: {
-        saturation: saturationAdjustmentFn(-1),
-        lightness: 18,
-      },
+      dark: {lightness: 56},
       meta: {
         figmaName: 'Border/Subdued',
       },
@@ -340,10 +337,7 @@ export const config: Config = {
         saturation: saturationAdjustmentFn(-1),
         lightness: 77.1,
       },
-      dark: {
-        saturation: saturationAdjustmentFn(-1),
-        lightness: 23,
-      },
+      dark: {lightness: 56},
       meta: {
         figmaName: 'BorderShadow/Subdued',
       },


### PR DESCRIPTION
This change gives us a consistent border around buttons in dark mode. This change quickly unblock the release so we don't have an influx of issues next week

Before: 
![image](https://screenshot.click/Storybook_2020-10-01_15-23-02.png)
After:
![image](https://screenshot.click/Storybook_2020-10-01_15-22-18.png)