### PR TITLE
Adjust primary action so it hits a11y specs

### DIFF
--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -624,7 +624,7 @@ export const config: Config = {
       name: 'actionPrimary',
       description:
         'Used as the background color for primary actions, and as the fill color for icons and the text color in navigation and tabs to communicate interaction states.',
-      light: {lightness: 47.3},
+      light: {lightness: 45.7},
       dark: {lightness: 47.3},
       meta: {
         figmaName: 'Action Primary/Default',


### PR DESCRIPTION
Fixes an issue I started seeing in the nav after defaulting to the new DL for Polaris v6

https://travis-ci.com/github/Shopify/polaris-react/jobs/424761097

![image](https://screenshot.click/Sandbox_-_CodeSandbox_2020-11-11_15-55-28.png)
![image](https://screenshot.click/Sandbox_-_CodeSandbox_2020-11-11_15-55-47.png)

This gives us a hex of `#007b5c` vs `#008060` cc @jessebc and gives us a 4.53 contrast against the nav background