### PR TITLE
Add text primary with variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added textPrimary with hovered and pressed variations ([#164](https://github.com/Shopify/polaris-tokens/pull/164))
+
 ## [2.15.0] - 2020-11-07
 
 - Changed borderShadow value ([#157](https://github.com/Shopify/polaris-tokens/pull/157))

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -691,6 +691,36 @@ export const config: Config = {
       },
     },
     {
+      name: 'textPrimary',
+      description:
+        'For use as primary text color on background. For use in text in components such as Navigation.',
+      light: {lightness: 45.7},
+      dark: {lightness: 52},
+      meta: {
+        figmaName: 'Text Primary/Default',
+      },
+    },
+    {
+      name: 'textPrimaryHovered',
+      description:
+        'For use as primary hovered text color on background. For use in text in components such as Navigation.',
+      light: {lightness: 40},
+      dark: {lightness: 58},
+      meta: {
+        figmaName: 'Text Primary/hover',
+      },
+    },
+    {
+      name: 'textPrimaryPressed',
+      description:
+        'For use as primary pressed text color on background. For use in text in components such as Navigation.',
+      light: {lightness: 34},
+      dark: {lightness: 64},
+      meta: {
+        figmaName: 'Text Primary/Pressed',
+      },
+    },
+    {
       name: 'surfacePrimarySelected',
       description:
         'Used as a surface color to indicate selected interactive states in navigation and tabs.',


### PR DESCRIPTION
I've created a sandbox for easy tophatting: https://codesandbox.io/s/reverent-herschel-cmtkh?file=/App.js
![image](https://screenshot.click/reverent-herschel-cmtkh_-_CodeSandbox_2020-12-17_11-29-39.png)

You can use dev tools to inspect the contrast ratio. I've made the background color `--p-background-selected` so we get a 4.5+ ratio event on selected nav items.

Dark mode also passes 😃