### PR TITLE
Restore icon and action tokens, lost in the build of #166

### DIFF
--- a/dist/color-filters.map.scss
+++ b/dist/color-filters.map.scss
@@ -229,4 +229,12 @@ $polaris-color-filters-map: (
   'color-white': (
     brightness(0) saturate(100%) invert(100%),
   ),
+  'icon': (
+    'base': brightness(0) saturate(100%) invert(36%) sepia(13%) saturate(137%)
+      hue-rotate(169deg) brightness(95%) contrast(87%),
+  ),
+  'action': (
+    'base': brightness(0) saturate(100%) invert(20%) sepia(59%) saturate(5557%)
+      hue-rotate(162deg) brightness(95%) contrast(101%),
+  ),
 );


### PR DESCRIPTION
Because of the way those tokens were introduced as part of [#149](https://github.com/Shopify/polaris-tokens/pull/149) (directly in the output, and not following the same naming convention as other colors), we're stuck with having to add them manually after a build.