### PR TITLE
Only trigger push CI on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - 'main'
 
 jobs:
   test_lint_build:


### PR DESCRIPTION
This matches the `on` config that we've finessed in [polaris-react's CI](https://github.com/Shopify/polaris-react/blob/main/.github/workflows/ci.yml)
