### PR TITLE
add css custom properties format

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,7 @@ const colorSystemFormats = [
   {transformType: 'android', formatType: 'android.xml'},
   {transformType: 'ios', formatType: 'ios.json'},
   {transformType: 'raw', formatType: 'figma.json'},
+  {transformType: 'web', formatType: 'custom-properties.css'},
 ];
 
 gulp.task('themes', (done) => {


### PR DESCRIPTION
Make color system variables available in a CSS custom properties format. See https://discourse.shopify.io/t/new-dl-polaris-v6-how-to-get-all-the-custom-properties-when-not-using-react/13647