### PR TITLE
Expose mergeConfigs and Configs from dist-modern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Added `mergeConfigs` and `Config` to the public API of `dist-modern/index.js` ([#180](https://github.com/Shopify/polaris-tokens/pull/180))
 
 ## [2.20.0] - 2021-02-24
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
 export {colorFactory} from './color-factory';
+
+export {mergeConfigs} from './utils';
+
+export type {Config} from './types';


### PR DESCRIPTION
These two exports are part of the public api, consumed by polaris-react
Lets expose them at the top level of modern so apps don't have go reach
deep

This helps set us up for the future where we switch importing `@shopify/polaris-tokens` to look at the modern stuff instead of pulling in legacy things.

Once this is merged and released we can update polaris-react to stop it reaching deep:

```diff
- import {mergeConfigs} from '@shopify/polaris-tokens/dist-modern/utils';
+ import {mergeConfigs} from '@shopify/polaris-tokens/dist-modern';

// and

- import type {Config} from '@shopify/polaris-tokens/dist-modern/types';
+ import type {Config} from '@shopify/polaris-tokens/dist-modern';
```
