### PR TITLE
Bring back icon/action color filters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,7 @@
     "**/.DS_Store": true,
     "**/.git": true,
     "**/node_modules": true,
-    "{build,dist-modern,dist}/": true
+    "{build,dist-modern}/": true
   },
   "html.format.indentHandlebars": true
 }

--- a/dist/color-filters.color-map.scss
+++ b/dist/color-filters.color-map.scss
@@ -137,4 +137,12 @@ $polaris-color-filters: (
   'white': (
     'base': brightness(0) saturate(100%) invert(100%),
   ),
+  'icon': (
+    'base': brightness(0) saturate(100%) invert(36%) sepia(13%) saturate(137%)
+      hue-rotate(169deg) brightness(95%) contrast(87%),
+  ),
+  'action': (
+    'base': brightness(0) saturate(100%) invert(20%) sepia(59%) saturate(5557%)
+      hue-rotate(162deg) brightness(95%) contrast(101%),
+  ),
 );


### PR DESCRIPTION
- This was added to a single dist file instead of source in #149
- It was then removed when somebody comitted a build in #166
- That removal was noticed and "fixed" in #168 except it added these
  lines to color-filters.map.scss, NOT color-filters.color-map.scss or some source file

Here they are back in the original file.

Ideally this should be added to all color representations but the dist
folder is basically deprecated now and generating from a single source
has been removed.