### PR TITLE
Fix array reference in mergeConfigs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export function saturationAdjustmentFn(adjustment: number) {
 export function mergeConfigs(base: Config, extended: Config) {
   return Object.entries(base).reduce((accumulator, [role, variants]) => {
     const extendedVariants = extended[role];
-    const mergedVariants = variants;
+    const mergedVariants = [...variants];
 
     if (extendedVariants != null) {
       extendedVariants.forEach((variant) => {


### PR DESCRIPTION
This fixes an issue we are seeing with `ThemeProvider`s in Polaris React where a child theme config is mutating a parent. The issue is where we merge the configs, we are modifying the array reference passed into it, instead of copying it into a new array.

You can see a demo of the bug in this codesandbox: https://codesandbox.io/s/adoring-thunder-yni1v?file=/App.js