### PR TITLE
Bump tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
   },
   "dependencies": {
     "hsluv": "^0.1.0",
-    "tslib": "^1.14.1"
+    "tslib": "^2.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15445,6 +15445,11 @@ tslib@^2, tslib@^2.0.0, tslib@^2.0.3, tslib@~2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"


### PR DESCRIPTION
Bump package `tslib` from `1.14.1` to `2.3.1`.

### Why am I doing this?

tslib version 1 exports an ES module without a default export. Which causes `polaris-token` and all packages depends on this package not working for rails 7 (If you are using the default `importmap-rails`).

Related https://github.com/rails/importmap-rails/issues/87#issuecomment-1000904472